### PR TITLE
StartCollecting return DotNetRuntimeStatsCollector instead of IDispos…

### DIFF
--- a/src/App.Metrics.DotNetRuntime/App.Metrics.DotNetRuntime.csproj
+++ b/src/App.Metrics.DotNetRuntime/App.Metrics.DotNetRuntime.csproj
@@ -4,7 +4,7 @@
         <RootNamespace>App.Metrics.DotNetRuntime</RootNamespace>
         <AssemblyName>App.Metrics.DotNetRuntime</AssemblyName>
         <PackageId>App.Metrics.DotNetRuntime</PackageId>
-        <Version>1.1.0</Version>
+        <Version>1.1.1</Version>
         <Authors>Seif Attar</Authors>
         <PackageTags>App.Metrics runtime metrics gc jit threadpool contention stats</PackageTags>
         <PackageProjectUrl>https://github.com/opentable/AppMetrics.DotNetRuntime</PackageProjectUrl>

--- a/src/App.Metrics.DotNetRuntime/DotNetRuntimeStatsBuilder.cs
+++ b/src/App.Metrics.DotNetRuntime/DotNetRuntimeStatsBuilder.cs
@@ -56,7 +56,7 @@ namespace App.Metrics.DotNetRuntime
             /// can be disposed of to stop metric collection.
             /// </summary>
             /// <returns></returns>
-            public IDisposable StartCollecting()
+            public DotNetRuntimeStatsCollector StartCollecting()
             {
                 var runtimeStatsCollector = new DotNetRuntimeStatsCollector(StatsCollectors.ToImmutableHashSet(), _errorHandler, _debugMetrics, _metrics);
                 runtimeStatsCollector.RegisterMetrics(_metrics);

--- a/src/App.Metrics.DotNetRuntime/DotNetRuntimeStatsCollector.cs
+++ b/src/App.Metrics.DotNetRuntime/DotNetRuntimeStatsCollector.cs
@@ -10,7 +10,7 @@ using App.Metrics.Gauge;
 
 namespace App.Metrics.DotNetRuntime
 {
-    internal sealed class DotNetRuntimeStatsCollector :
+    public sealed class DotNetRuntimeStatsCollector :
         IDisposable
 
     {


### PR DESCRIPTION
…able

So that if consumer if registering the metrics with dependendcy
injection, they can register DotNetRuntimeStatsCollector with DependencyInjection and then resolve it so that the builder is called