### PR TITLE
DotNetRuntimeStatsBuilder change

### DIFF
--- a/examples/AspNetCoreExample/Startup.cs
+++ b/examples/AspNetCoreExample/Startup.cs
@@ -44,7 +44,7 @@ namespace AspNetCoreExample
             {
                 Console.WriteLine("Enabling prometheus-net.DotNetStats...");
 
-                DotNetRuntimeStatsBuilder.Customize(metrics)
+                DotNetRuntimeStatsBuilder.Customize()
                     .WithThreadPoolSchedulingStats()
                     .WithContentionStats()
                     .WithGcStats()
@@ -52,7 +52,7 @@ namespace AspNetCoreExample
                     .WithThreadPoolStats()
                     .WithErrorHandler(ex => Console.WriteLine("ERROR: " + ex.ToString()))
                     .WithDebuggingMetrics(true)
-                    .StartCollecting();
+                    .StartCollecting(metrics);
             }
 
             app.UseHttpsRedirection();

--- a/src/App.Metrics.DotNetRuntime/DotNetRuntimeStatsBuilder.cs
+++ b/src/App.Metrics.DotNetRuntime/DotNetRuntimeStatsBuilder.cs
@@ -43,7 +43,7 @@ namespace App.Metrics.DotNetRuntime
             private Action<Exception> _errorHandler;
             private bool _debugMetrics;
 
-            internal HashSet<Func<IMetrics, IEventSourceStatsCollector>> StatsCollectors { get; } = new HashSet<Func<IMetrics, IEventSourceStatsCollector>>(new TypeEquality<Func<IMetrics, IEventSourceStatsCollector>>());
+            internal HashSet<Func<IMetrics, IEventSourceStatsCollector>> StatsCollectors { get; } = new HashSet<Func<IMetrics, IEventSourceStatsCollector>>();
 
             /// <summary>
             /// Finishes configuration and starts collecting .NET runtime metrics. Returns a <see cref="IDisposable"/> that
@@ -140,19 +140,6 @@ namespace App.Metrics.DotNetRuntime
             {
                 _debugMetrics = generateDebugMetrics;
                 return this;
-            }
-
-            internal class TypeEquality<T> : IEqualityComparer<T>
-            {
-                public bool Equals(T x, T y)
-                {
-                    return x.GetType() == y.GetType();
-                }
-
-                public int GetHashCode(T obj)
-                {
-                    return obj.GetType().GetHashCode();
-                }
             }
         }
     }

--- a/src/App.Metrics.DotNetRuntime/DotNetRuntimeStatsBuilder.cs
+++ b/src/App.Metrics.DotNetRuntime/DotNetRuntimeStatsBuilder.cs
@@ -112,6 +112,11 @@ namespace App.Metrics.DotNetRuntime
                 StatsCollectors.Add(_ => statsCollector);
                 return this;
             }
+            public Builder WithCustomCollector(Func<IMetrics, IEventSourceStatsCollector> func)
+            {
+                StatsCollectors.Add(func);
+                return this;
+            }
 
             /// <summary>
             /// Specifies a function to call when an exception occurs within the .NET stats collectors.

--- a/src/App.Metrics.DotNetRuntime/DotNetRuntimeStatsCollector.cs
+++ b/src/App.Metrics.DotNetRuntime/DotNetRuntimeStatsCollector.cs
@@ -41,17 +41,17 @@ namespace App.Metrics.DotNetRuntime
             }
         }
 
-        public void RegisterMetrics(IMetrics metrics)
+        public void RegisterMetrics()
         {
             // Metrics have been registered, start the event listeners
             _eventListeners = _statsCollectors
-                .Select(sc => new DotNetEventListener(sc, _errorHandler, _enabledDebugging, metrics))
+                .Select(sc => new DotNetEventListener(sc, _errorHandler, _enabledDebugging, _metrics))
                 .ToArray();
 
-            _processInfoStatsCollector = new ProcessInfoStatsCollector(metrics);
+            _processInfoStatsCollector = new ProcessInfoStatsCollector(_metrics);
             _processInfoStatsCollector.Start();
 
-            SetupConstantMetrics(metrics);
+            SetupConstantMetrics(_metrics);
         }
 
         public void Dispose()

--- a/src/Benchmarks/Program.cs
+++ b/src/Benchmarks/Program.cs
@@ -29,7 +29,7 @@ namespace Benchmarks
             if (args.Length > 0 && args[0] == "metrics")
             {
                 var metrics = App.Metrics.AppMetrics.CreateDefaultBuilder().Build();
-                var collector = DotNetRuntimeStatsBuilder.Customize(metrics)
+                var collector = DotNetRuntimeStatsBuilder.Customize()
                     .WithContentionStats()
                     .WithThreadPoolStats()
                     .WithThreadPoolSchedulingStats();
@@ -41,7 +41,7 @@ namespace Benchmarks
                         
                 collector
                     .WithDebuggingMetrics(false)
-                    .StartCollecting();
+                    .StartCollecting(metrics);
             }
 
             var b2 = new byte[1024 * 1000];


### PR DESCRIPTION
* Pass IMetrics in StartCollecting, not in the constructor
* Added a new overload of WithCustomCollector with Func<IMetrics, IEventSourceStatsCollector>