### PR TITLE
Read AllocationAmount64 when handling gc allocation

### DIFF
--- a/src/App.Metrics.DotNetRuntime/StatsCollectors/GcStatsCollector.cs
+++ b/src/App.Metrics.DotNetRuntime/StatsCollectors/GcStatsCollector.cs
@@ -60,7 +60,7 @@ namespace App.Metrics.DotNetRuntime.StatsCollectors
             {
                 const uint lohHeapFlag = 0x1;
                 var heapLabelValue = ((uint) e.Payload[1] & lohHeapFlag) == lohHeapFlag ? "loh" : "soh";
-                _metrics.Measure.Meter.Mark(DotNetRuntimeMetricsRegistry.Meters.AllocatedBytes, new MetricTags("heap", heapLabelValue), (uint)e.Payload[0]);
+                _metrics.Measure.Meter.Mark(DotNetRuntimeMetricsRegistry.Meters.AllocatedBytes, new MetricTags("heap", heapLabelValue), Convert.ToInt64((UInt64)e.Payload[3]));
                 return;
             }
 


### PR DESCRIPTION
Noticed this when looking into performance isse.

payload[0] is AllocationAmount which is not accurate for large
allocations. Switching to use payload[3] which will give better accuracy
for bigger allocations